### PR TITLE
Removed morning challenges from learning resources

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -1,12 +1,5 @@
-# A selection of useful learning resources
+# Nelson and *dwyl*'s learning resources
 
-### Morning Challenges
-+ [Morning challenge repo](https://github.com/foundersandcoders/morning-challenge)
-
-### Nelson and dwyl extensive learning resources
 + [Nelson's learning READMEs](https://github.com/search?q=user%3Anelsonic+learn)
 + [dwyl learning READMEs](https://github.com/search?q=user%3Adwyl+learn)
 
-### Various other repos 
-+ [A simple Node.js HTTP server using Shot](https://github.com/foundersandcoders/elevator-mechanic)
-+ [A super simple starter kit for Node.js](https://github.com/sofer/sssk)


### PR DESCRIPTION
I don't think it's necessarily a great idea to have a link to the challenges repo in the learning resources.
